### PR TITLE
Namespace extension added as signed attribute

### DIFF
--- a/src/java/main/esg/idp/server/web/OpenidServer.java
+++ b/src/java/main/esg/idp/server/web/OpenidServer.java
@@ -88,7 +88,7 @@ public class OpenidServer {
 		if (LOG.isDebugEnabled()) LOG.debug("Configuring ServerManager with OpenID Server URL: "+openidServerUrl);
 		
 		// fields signed by the Openid Server
-		manager.setSignFields("return_to,assoc_handle,claimed_id,identity"); // OpenID 1.x
+		manager.setSignFields("return_to,assoc_handle,claimed_id,identity" + ",ns." + AxMessage.OPENID_NS_AX); // OpenID 1.x
 		manager.setSignExtensions(new String[]{AxMessage.OPENID_NS_AX});
 		
 	}


### PR DESCRIPTION
Openid4Java Message checks signed params list but ns.ext1 is not found.
