### PR TITLE
Enable Attribute Exchange in OP Identifier mode

### DIFF
--- a/src/java/main/esg/idp/yadis/impl/YadisServiceImpl.java
+++ b/src/java/main/esg/idp/yadis/impl/YadisServiceImpl.java
@@ -167,7 +167,7 @@ public class YadisServiceImpl implements YadisService {
 	  sb.append("<Service priority=\"0\">")
 	    .append("<Type>http://specs.openid.net/auth/2.0/server</Type>") /*http://specs.openid.net/auth/2.0/signon*/
 		/*.append("<Type>http://specs.openid.net/auth/2.0</Type>") */   /*http://openid.net/signon/1.0*/
-		/*.append("<Type>http://openid.net/srv/ax/1.0</Type>")*/
+		.append("<Type>http://openid.net/srv/ax/1.0</Type>")
 		.append("<URI>").append(idpProviderUrl.toString()).append("</URI>")
 		/*.append("<LocalID>").append(openid).append("</LocalID>")*/ /* kltsa 18/06/2014: Skip the local id tag.*/
 	    .append("</Service>");


### PR DESCRIPTION
cog 'requires' to have some user attributes (first/last name, email) set.
Requesting these currently fails in OP Identifier mode (i.e. selecting the IdP from the provided list) as the OP doesn't announce that it supports AX and thus they aren't included with the auth request.